### PR TITLE
[codex] Add daily AI token usage leaderboard

### DIFF
--- a/apps/web/src/app/(app)/(leaderboard)/page-client.tsx
+++ b/apps/web/src/app/(app)/(leaderboard)/page-client.tsx
@@ -14,8 +14,8 @@ import { add, format, isAfter, isBefore, isFuture, isToday, isYesterday, sub } f
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTheme } from 'next-themes';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { LuChevronLeft, LuChevronRight, LuLoaderCircle, LuUser } from 'react-icons/lu';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { LuChevronLeft, LuChevronRight, LuClock3, LuLoaderCircle, LuSparkles, LuUser } from 'react-icons/lu';
 import { TbUserDown } from 'react-icons/tb';
 
 import HoverDevCard from '~/components/HoverDevCard';
@@ -34,6 +34,7 @@ export default function PageClient() {
 
 const FROM_DTAE = new Date(2025, 0, 1);
 const TO_DTAE = new Date();
+type LeaderboardMode = 'time' | 'tokens';
 
 function LeadersTable() {
   const { currentUser } = useAuth();
@@ -41,7 +42,7 @@ function LeadersTable() {
   const searchParams = useSearchParams();
   const utils = api.useUtils();
   const pathname = usePathname();
-  const [hasRetried, setHasRetried] = useState(false);
+  const retriedQueryKeyRef = useRef<string | null>(null);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const router = useRouter();
 
@@ -70,9 +71,13 @@ function LeadersTable() {
     return Number(page);
   }, [searchParams]);
 
+  const mode = useMemo<LeaderboardMode>(() => {
+    return searchParams.get('mode') === 'tokens' ? 'tokens' : 'time';
+  }, [searchParams]);
+
   const dateString = useMemo(() => dateToDateString(currentDate), [currentDate]);
 
-  const leadersQuery = api.leaderboard.getLeaders.useQuery({ date: dateString, page });
+  const leadersQuery = api.leaderboard.getLeaders.useQuery({ date: dateString, mode, page });
   const programLanguagesQuery = api.languages.getAllProgramLanguages.useQuery();
   const editorsQuery = api.editors.getAllEditors.useQuery();
 
@@ -96,6 +101,28 @@ function LeadersTable() {
     return (currentUser ? (leadersQuery.data?.items.findIndex((leader) => leader.user.id === currentUser.id) ?? -1) : -1) + 1;
   }, [currentUser, leadersQuery.data?.items]);
 
+  const createUrl = useCallback(
+    (params: URLSearchParams) => {
+      const search = params.toString();
+      return search ? `${pathname}?${search}` : pathname;
+    },
+    [pathname],
+  );
+
+  const handleSetMode = useCallback(
+    (mode: LeaderboardMode) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (mode === 'tokens') {
+        params.set('mode', mode);
+      } else {
+        params.delete('mode');
+      }
+      params.delete('page');
+      router.push(createUrl(params));
+    },
+    [createUrl, router, searchParams],
+  );
+
   const handleSetPage = useCallback(
     (page: number, replace?: boolean) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -104,14 +131,14 @@ function LeadersTable() {
       } else {
         params.delete('page');
       }
-      const url = pathname + params.toString() ? `?${params.toString()}` : '';
+      const url = createUrl(params);
       if (replace) {
         router.replace(url);
       } else {
         router.push(url);
       }
     },
-    [pathname, router, searchParams],
+    [createUrl, router, searchParams],
   );
 
   const handleSetDate = useCallback(
@@ -122,26 +149,26 @@ function LeadersTable() {
       } else {
         params.set('date', dateToDateString(date));
       }
+      params.delete('page');
 
-      const url = pathname + params.toString() ? `?${params.toString()}` : '';
+      const url = createUrl(params);
       if (replace) {
         router.replace(url);
       } else {
         router.push(url);
       }
     },
-    [pathname, router, searchParams],
+    [createUrl, router, searchParams],
   );
 
   // refetch leaders once if we don't have any for the current day, because it syncs with WakaTime on the first fetch
   useEffect(() => {
-    if (leadersQuery.isSuccess && !hasRetried) {
-      if (leadersQuery.data.totalItems === 0) {
-        setHasRetried(true);
-        void utils.leaderboard.getLeaders.refetch();
-      }
+    const retryKey = `${mode}:${dateString}`;
+    if (leadersQuery.isSuccess && retriedQueryKeyRef.current !== retryKey && leadersQuery.data.totalItems === 0) {
+      retriedQueryKeyRef.current = retryKey;
+      void utils.leaderboard.getLeaders.refetch();
     }
-  }, [leadersQuery.isSuccess, leadersQuery.data?.totalItems, hasRetried, utils.leaderboard.getLeaders]);
+  }, [dateString, leadersQuery.isSuccess, leadersQuery.data?.totalItems, mode, utils.leaderboard.getLeaders]);
 
   // If search params date is a future date (after TO_DATE) or before 2025 (before FROM_DATE) we will revert back to today
   useEffect(() => {
@@ -158,8 +185,27 @@ function LeadersTable() {
 
   return (
     <>
-      <div className="mb-4 flex items-center gap-4">
-        <div className="flex-1"></div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant={mode === 'time' ? 'default' : 'outline'}
+            aria-pressed={mode === 'time'}
+            onClick={() => handleSetMode('time')}
+            className="cursor-pointer"
+          >
+            <LuClock3 />
+            Coding Time
+          </Button>
+          <Button
+            variant={mode === 'tokens' ? 'default' : 'outline'}
+            aria-pressed={mode === 'tokens'}
+            onClick={() => handleSetMode('tokens')}
+            className="cursor-pointer"
+          >
+            <LuSparkles />
+            AI Tokens
+          </Button>
+        </div>
         <div className="flex gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -188,13 +234,11 @@ function LeadersTable() {
                 mode="single"
                 selected={currentDate}
                 onSelect={(date) => {
-                  if (date) {
-                    const d = new Date();
-                    d.setUTCFullYear(date.getFullYear());
-                    d.setUTCMonth(date.getMonth());
-                    d.setUTCDate(date.getDate());
-                    handleSetDate(d);
-                  }
+                  const d = new Date();
+                  d.setUTCFullYear(date.getFullYear());
+                  d.setUTCMonth(date.getMonth());
+                  d.setUTCDate(date.getDate());
+                  handleSetDate(d);
                   setDatePickerOpen(false);
                 }}
                 initialFocus
@@ -243,9 +287,19 @@ function LeadersTable() {
                 </div>
               </TableHead>
               <TableHead>User</TableHead>
-              <TableHead>{isToday(currentDate) ? 'Time Today' : formatDate(currentDate)}</TableHead>
-              <TableHead>Languages</TableHead>
-              <TableHead>Editors</TableHead>
+              {mode === 'tokens' ? (
+                <>
+                  <TableHead>{isToday(currentDate) ? 'Tokens Today' : formatDate(currentDate)}</TableHead>
+                  <TableHead>Input Tokens</TableHead>
+                  <TableHead>Output Tokens</TableHead>
+                </>
+              ) : (
+                <>
+                  <TableHead>{isToday(currentDate) ? 'Time Today' : formatDate(currentDate)}</TableHead>
+                  <TableHead>Languages</TableHead>
+                  <TableHead>Editors</TableHead>
+                </>
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -267,9 +321,11 @@ function LeadersTable() {
               <TableRow>
                 <TableCell colSpan={5}>
                   <div className="text-muted-foreground p-4 text-center">
-                    {isToday(currentDate)
-                      ? `It’s a new day, the clock resets at midnight ${leadersQuery.data.timezone}. Get your coding on!`
-                      : 'No devs found.'}
+                    {mode === 'tokens'
+                      ? 'No AI token usage found.'
+                      : isToday(currentDate)
+                        ? `It’s a new day, the clock resets at midnight ${leadersQuery.data.timezone}. Get your coding on!`
+                        : 'No devs found.'}
                   </div>
                 </TableCell>
               </TableRow>
@@ -343,53 +399,69 @@ function LeadersTable() {
                       </div>
                     </div>
                   </TableCell>
-                  <TableCell>
-                    <div className="text-lg">{formatSeconds(leader.totalSeconds)}</div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex max-w-md min-w-xs flex-wrap gap-2">
-                      {leader.languages.map((language, index) => {
-                        if (language.totalSeconds < 60 && index > 0) {
-                          return null;
-                        }
-                        const bgColor = languages.get(language.programLanguageName) ?? undefined;
-                        const color = getReadableTextColor(bgColor, theme === 'dark' ? 'white' : 'black');
-                        return (
-                          <Button
-                            key={language.programLanguageName}
-                            size="sm"
-                            variant="secondary"
-                            className="h-fit px-2 py-1.5 text-xs"
-                            style={{ backgroundColor: bgColor, color }}
-                          >
-                            {`${language.programLanguageName} - ${formatSeconds(language.totalSeconds)}`}
-                          </Button>
-                        );
-                      })}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex max-w-md min-w-xs flex-wrap gap-2">
-                      {leader.editors.map((editor, index) => {
-                        if (editor.totalSeconds < 60 && index > 0) {
-                          return null;
-                        }
-                        const bgColor = editors.get(editor.editorName) ?? undefined;
-                        const color = getReadableTextColor(bgColor, theme === 'dark' ? 'white' : 'black');
-                        return (
-                          <Button
-                            key={editor.editorName}
-                            size="sm"
-                            variant="secondary"
-                            className="h-fit px-2 py-1.5 text-xs"
-                            style={{ backgroundColor: bgColor, color }}
-                          >
-                            {`${editor.editorName} - ${formatSeconds(editor.totalSeconds)}`}
-                          </Button>
-                        );
-                      })}
-                    </div>
-                  </TableCell>
+                  {mode === 'tokens' ? (
+                    <>
+                      <TableCell>
+                        <div className="text-lg font-medium">{formatTokens(leader.aiTotalTokens)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="text-muted-foreground">{formatTokens(leader.aiInputTokens)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="text-muted-foreground">{formatTokens(leader.aiOutputTokens)}</div>
+                      </TableCell>
+                    </>
+                  ) : (
+                    <>
+                      <TableCell>
+                        <div className="text-lg">{formatSeconds(leader.totalSeconds)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex max-w-md min-w-xs flex-wrap gap-2">
+                          {leader.languages.map((language, index) => {
+                            if (language.totalSeconds < 60 && index > 0) {
+                              return null;
+                            }
+                            const bgColor = languages.get(language.programLanguageName) ?? undefined;
+                            const color = getReadableTextColor(bgColor, theme === 'dark' ? 'white' : 'black');
+                            return (
+                              <Button
+                                key={language.programLanguageName}
+                                size="sm"
+                                variant="secondary"
+                                className="h-fit px-2 py-1.5 text-xs"
+                                style={{ backgroundColor: bgColor, color }}
+                              >
+                                {`${language.programLanguageName} - ${formatSeconds(language.totalSeconds)}`}
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex max-w-md min-w-xs flex-wrap gap-2">
+                          {leader.editors.map((editor, index) => {
+                            if (editor.totalSeconds < 60 && index > 0) {
+                              return null;
+                            }
+                            const bgColor = editors.get(editor.editorName) ?? undefined;
+                            const color = getReadableTextColor(bgColor, theme === 'dark' ? 'white' : 'black');
+                            return (
+                              <Button
+                                key={editor.editorName}
+                                size="sm"
+                                variant="secondary"
+                                className="h-fit px-2 py-1.5 text-xs"
+                                style={{ backgroundColor: bgColor, color }}
+                              >
+                                {`${editor.editorName} - ${formatSeconds(editor.totalSeconds)}`}
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      </TableCell>
+                    </>
+                  )}
                 </TableRow>
               ))
             )}
@@ -406,6 +478,10 @@ function LeadersTable() {
 
 function numberWithCommas(x: number) {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function formatTokens(totalTokens: number) {
+  return numberWithCommas(Math.round(totalTokens));
 }
 
 function formatSeconds(totalSeconds: number) {

--- a/apps/web/src/app/(infra)/login/route.ts
+++ b/apps/web/src/app/(infra)/login/route.ts
@@ -50,7 +50,7 @@ export const GET = async (req: NextRequest) => {
     client_id: env.WAKATIME_APP_ID,
     response_type: 'code',
     redirect_uri: WAKATIME_REDIRECT_URI,
-    scope: 'email,read_summaries.editors,read_summaries.languages',
+    scope: 'email,read_summaries',
     state: btoa(JSON.stringify(state)),
   });
   const redirectUrl = `${WAKATIME_AUTHORIZE_URL}?${params.toString()}`;

--- a/packages/api/src/routers/leaderboard.ts
+++ b/packages/api/src/routers/leaderboard.ts
@@ -18,6 +18,7 @@ export const leaderboardRouter = createTRPCRouter({
         date: z.string().date().optional(),
         page: z.number().positive().min(1).nullish(),
         limit: z.number().positive().min(1).max(500).optional(),
+        mode: z.enum(['time', 'tokens']).optional(),
       }),
     )
     .query(async ({ ctx: { currentUser }, input }) => {
@@ -30,6 +31,7 @@ export const leaderboardRouter = createTRPCRouter({
       const page = input.page ?? 1;
 
       const date = input.date ?? today();
+      const mode = input.mode ?? 'time';
 
       const Languages = db.$with('UserSummaryLanguage').as(
         db
@@ -42,16 +44,26 @@ export const leaderboardRouter = createTRPCRouter({
           .groupBy(UserSummaryLanguage.userId),
       );
 
-      const leaders = await db
-        .with(Languages)
-        .select()
-        .from(UserSummary)
-        .innerJoin(User, eq(User.id, UserSummary.userId))
-        .leftJoin(Languages, eq(Languages.userId, UserSummary.userId))
-        .where(and(eq(UserSummary.date, date), gt(UserSummary.totalSeconds, 60), gt(Languages.count, 0)))
-        .orderBy(desc(UserSummary.totalSeconds))
-        .limit(limit)
-        .offset(limit * (page - 1));
+      const leaders =
+        mode === 'tokens'
+          ? await db
+              .select()
+              .from(UserSummary)
+              .innerJoin(User, eq(User.id, UserSummary.userId))
+              .where(and(eq(UserSummary.date, date), gt(UserSummary.aiTotalTokens, 0)))
+              .orderBy(desc(UserSummary.aiTotalTokens), desc(UserSummary.totalSeconds))
+              .limit(limit)
+              .offset(limit * (page - 1))
+          : await db
+              .with(Languages)
+              .select()
+              .from(UserSummary)
+              .innerJoin(User, eq(User.id, UserSummary.userId))
+              .leftJoin(Languages, eq(Languages.userId, UserSummary.userId))
+              .where(and(eq(UserSummary.date, date), gt(UserSummary.totalSeconds, 60), gt(Languages.count, 0)))
+              .orderBy(desc(UserSummary.totalSeconds))
+              .limit(limit)
+              .offset(limit * (page - 1));
 
       const items = await Promise.all(
         leaders.map(async (leader) => {
@@ -86,6 +98,9 @@ export const leaderboardRouter = createTRPCRouter({
           return {
             date,
             totalSeconds: leader.UserSummary.totalSeconds,
+            aiInputTokens: leader.UserSummary.aiInputTokens,
+            aiOutputTokens: leader.UserSummary.aiOutputTokens,
+            aiTotalTokens: leader.UserSummary.aiTotalTokens,
             user,
             languages,
             editors,
@@ -93,13 +108,20 @@ export const leaderboardRouter = createTRPCRouter({
         }),
       );
 
-      const totalCount = await db
-        .with(Languages)
-        .select({ count: count() })
-        .from(UserSummary)
-        .leftJoin(Languages, eq(Languages.userId, UserSummary.userId))
-        .where(and(eq(UserSummary.date, date), gt(UserSummary.totalSeconds, 60), gt(Languages.count, 0)))
-        .then((res) => res[0]?.count ?? 0);
+      const totalCount =
+        mode === 'tokens'
+          ? await db
+              .select({ count: count() })
+              .from(UserSummary)
+              .where(and(eq(UserSummary.date, date), gt(UserSummary.aiTotalTokens, 0)))
+              .then((res) => res[0]?.count ?? 0)
+          : await db
+              .with(Languages)
+              .select({ count: count() })
+              .from(UserSummary)
+              .leftJoin(Languages, eq(Languages.userId, UserSummary.userId))
+              .where(and(eq(UserSummary.date, date), gt(UserSummary.totalSeconds, 60), gt(Languages.count, 0)))
+              .then((res) => res[0]?.count ?? 0);
 
       if (totalCount === 0) {
         await syncSummariesForAllUsers.enqueue();
@@ -109,6 +131,7 @@ export const leaderboardRouter = createTRPCRouter({
         date,
         items,
         limit,
+        mode,
         page,
         prevPage: page > 2 ? page - 1 : null,
         nextPage: leaders.length >= limit ? page + 1 : null,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -175,5 +175,7 @@ export interface WakaTimeSummary {
     minutes: number;
     text: string;
     total_seconds: number;
+    ai_input_tokens?: number;
+    ai_output_tokens?: number;
   };
 }

--- a/packages/db/drizzle/0020_lucky_arachne.sql
+++ b/packages/db/drizzle/0020_lucky_arachne.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "UserSummary" ADD COLUMN "aiInputTokens" bigint DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "UserSummary" ADD COLUMN "aiOutputTokens" bigint DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "UserSummary" ADD COLUMN "aiTotalTokens" bigint DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX "UserSummary_date_aiTotalTokens_index" ON "UserSummary" USING btree ("date" DESC NULLS LAST,"aiTotalTokens" DESC NULLS LAST);

--- a/packages/db/drizzle/meta/0020_snapshot.json
+++ b/packages/db/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,830 @@
+{
+  "id": "362fe1d7-3ab4-4349-8e3d-2b9a19922b04",
+  "prevId": "50aad65a-1828-45be-b6e3-351ab2979153",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.DailyLeaderboard": {
+      "name": "DailyLeaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Editor": {
+      "name": "Editor",
+      "schema": "",
+      "columns": {
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "citext",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LeaderboardConfig": {
+      "name": "LeaderboardConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isInviteOnly": {
+          "name": "isInviteOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inviteCode": {
+          "name": "inviteCode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastSyncedStatsAt": {
+          "name": "lastSyncedStatsAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MonthlyLeaderboard": {
+      "name": "MonthlyLeaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "monthEndDate": {
+          "name": "monthEndDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProgramLanguage": {
+      "name": "ProgramLanguage",
+      "schema": "",
+      "columns": {
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "citext",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProgramLanguageAlias": {
+      "name": "ProgramLanguageAlias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "citext",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "programLanguageName": {
+          "name": "programLanguageName",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProgramLanguageAlias_programLanguageName_index": {
+          "name": "ProgramLanguageAlias_programLanguageName_index",
+          "columns": [
+            {
+              "expression": "programLanguageName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProgramLanguageAlias_programLanguageName_ProgramLanguage_name_fk": {
+          "name": "ProgramLanguageAlias_programLanguageName_ProgramLanguage_name_fk",
+          "tableFrom": "ProgramLanguageAlias",
+          "tableTo": "ProgramLanguage",
+          "columnsFrom": [
+            "programLanguageName"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WeeklyLeaderboard": {
+      "name": "WeeklyLeaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "weekEndDate": {
+          "name": "weekEndDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSummary": {
+      "name": "UserSummary",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSeconds": {
+          "name": "totalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiInputTokens": {
+          "name": "aiInputTokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "aiOutputTokens": {
+          "name": "aiOutputTokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "aiTotalTokens": {
+          "name": "aiTotalTokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "UserSummary_date_totalSeconds_index": {
+          "name": "UserSummary_date_totalSeconds_index",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "totalSeconds",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSummary_date_aiTotalTokens_index": {
+          "name": "UserSummary_date_aiTotalTokens_index",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "aiTotalTokens",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSummary_userId_User_id_fk": {
+          "name": "UserSummary_userId_User_id_fk",
+          "tableFrom": "UserSummary",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserSummary_date_userId_unique": {
+          "name": "UserSummary_date_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSummaryEditor": {
+      "name": "UserSummaryEditor",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editorName": {
+          "name": "editorName",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSeconds": {
+          "name": "totalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSummaryEditor_date_totalSeconds_index": {
+          "name": "UserSummaryEditor_date_totalSeconds_index",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "totalSeconds",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSummaryEditor_userId_User_id_fk": {
+          "name": "UserSummaryEditor_userId_User_id_fk",
+          "tableFrom": "UserSummaryEditor",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UserSummaryEditor_editorName_Editor_name_fk": {
+          "name": "UserSummaryEditor_editorName_Editor_name_fk",
+          "tableFrom": "UserSummaryEditor",
+          "tableTo": "Editor",
+          "columnsFrom": [
+            "editorName"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserSummaryEditor_date_userId_editorName_unique": {
+          "name": "UserSummaryEditor_date_userId_editorName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date",
+            "userId",
+            "editorName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSummaryLanguage": {
+      "name": "UserSummaryLanguage",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "programLanguageName": {
+          "name": "programLanguageName",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSeconds": {
+          "name": "totalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSummaryLanguage_date_totalSeconds_index": {
+          "name": "UserSummaryLanguage_date_totalSeconds_index",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "totalSeconds",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSummaryLanguage_userId_User_id_fk": {
+          "name": "UserSummaryLanguage_userId_User_id_fk",
+          "tableFrom": "UserSummaryLanguage",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UserSummaryLanguage_programLanguageName_ProgramLanguage_name_fk": {
+          "name": "UserSummaryLanguage_programLanguageName_ProgramLanguage_name_fk",
+          "tableFrom": "UserSummaryLanguage",
+          "tableTo": "ProgramLanguage",
+          "columnsFrom": [
+            "programLanguageName"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserSummaryLanguage_date_userId_programLanguageName_unique": {
+          "name": "UserSummaryLanguage_date_userId_programLanguageName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date",
+            "userId",
+            "programLanguageName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AuditLog_userId_createdAt_index": {
+          "name": "AuditLog_userId_createdAt_index",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_userId_index": {
+          "name": "AuditLog_userId_index",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_userId_User_id_fk": {
+          "name": "AuditLog_userId_User_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullName": {
+          "name": "fullName",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wonderfulDevUsername": {
+          "name": "wonderfulDevUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOwner": {
+          "name": "isOwner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedStatsAt": {
+          "name": "lastSyncedStatsAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "User_username_index": {
+          "name": "User_username_index",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_sessionId_unique": {
+          "name": "User_sessionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionId"
+          ]
+        },
+        "User_username_unique": {
+          "name": "User_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "User_isOwner_unique": {
+          "name": "User_isOwner_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "isOwner"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1748954036827,
       "tag": "0019_perpetual_jocasta",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1780894904239,
+      "tag": "0020_lucky_arachne",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/stats.ts
+++ b/packages/db/src/schema/stats.ts
@@ -1,4 +1,4 @@
-import { date, index, integer, pgTable, unique } from 'drizzle-orm/pg-core';
+import { bigint, date, index, integer, pgTable, unique } from 'drizzle-orm/pg-core';
 
 import { Editor, ProgramLanguage } from './leaderboards';
 import { citext } from './types';
@@ -12,8 +12,15 @@ export const UserSummary = pgTable(
       .notNull()
       .references(() => User.id, { onDelete: 'cascade' }),
     totalSeconds: integer().notNull(),
+    aiInputTokens: bigint({ mode: 'number' }).notNull().default(0),
+    aiOutputTokens: bigint({ mode: 'number' }).notNull().default(0),
+    aiTotalTokens: bigint({ mode: 'number' }).notNull().default(0),
   },
-  (table) => [unique().on(table.date, table.userId), index().on(table.date.desc(), table.totalSeconds.desc())],
+  (table) => [
+    unique().on(table.date, table.userId),
+    index().on(table.date.desc(), table.totalSeconds.desc()),
+    index().on(table.date.desc(), table.aiTotalTokens.desc()),
+  ],
 );
 
 export const UserSummaryLanguage = pgTable(

--- a/packages/tasks/src/summaries/syncUserSummaries.ts
+++ b/packages/tasks/src/summaries/syncUserSummaries.ts
@@ -96,17 +96,26 @@ export const syncUserSummaries = wakaq.task(
 );
 
 async function _processSummary(user: { id: string; accessToken: string; lastSyncedStatsAt: Date | null }, summary: Summary) {
+  const aiInputTokens = summary.grand_total.ai_input_tokens ?? 0;
+  const aiOutputTokens = summary.grand_total.ai_output_tokens ?? 0;
+
   await db
     .insert(UserSummary)
     .values({
       date: summary.range.date,
       userId: user.id,
       totalSeconds: Math.floor(summary.grand_total.total_seconds),
+      aiInputTokens,
+      aiOutputTokens,
+      aiTotalTokens: aiInputTokens + aiOutputTokens,
     })
     .onConflictDoUpdate({
       target: [UserSummary.date, UserSummary.userId],
       set: {
         totalSeconds: Math.floor(summary.grand_total.total_seconds),
+        aiInputTokens,
+        aiOutputTokens,
+        aiTotalTokens: aiInputTokens + aiOutputTokens,
       },
     });
 

--- a/packages/tasks/src/types.ts
+++ b/packages/tasks/src/types.ts
@@ -36,6 +36,8 @@ export interface Summary {
     hours: number;
     minutes: number;
     total_seconds: number;
+    ai_input_tokens?: number;
+    ai_output_tokens?: number;
     digital: string;
     decimal: string;
     text: string;


### PR DESCRIPTION
## What changed

- Adds daily AI input/output/total token fields to synced WakaTime summaries.
- Adds a `tokens` leaderboard mode sorted by daily total AI token usage.
- Adds an `AI Tokens` switch on the leaderboard UI alongside the existing coding-time view.
- Requests the broader `read_summaries` OAuth scope for new logins so WakaTime summary token fields are available.

## Validation

- `pnpm exec eslint "apps/web/src/app/(app)/(leaderboard)/page-client.tsx" "apps/web/src/app/(infra)/login/route.ts"`
- `pnpm -F @workspace/api lint`
- `pnpm -F @workspace/db lint`
- `pnpm -F @workspace/tasks lint`
- `pnpm --filter @workspace/db exec tsc --noEmit --project tsconfig.json`
- `pnpm --filter @workspace/tasks exec tsc --noEmit --project tsconfig.json`
- `pnpm --filter @workspace/core exec tsc --noEmit --project tsconfig.json`
- `DATABASE_URL=... pnpm -F @workspace/db check`
- `SKIP_ENV_VALIDATION=1 DATABASE_URL=... NEXT_PUBLIC_APP_DOMAIN=localhost NEXT_PUBLIC_BASE_URL=http://localhost:3000 JWT_SECRET=dev WAKATIME_APP_ID=dev WAKATIME_APP_SECRET=dev pnpm build:web`

## Notes

Full repo lint currently fails on existing unrelated issues in `packages/external/src/env.ts`, `apps/web/src/app/admin/tasks/[task]/_components/task-details.tsx`, and `packages/core/src/utils/helpers.ts`. Package-wide type checks for web/API are also blocked by existing unrelated `baseUrl` deprecation and admin task spread errors.
